### PR TITLE
bump to akka 2.3.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalacOptions := Seq(
 
 libraryDependencies ++= {
   val version = Map(
-    "akka"         -> "2.3.9",
+    "akka"         -> "2.3.12",
     "akka-stream"  -> "2.0-M2",
     "postgresql"   -> "9.4-1201-jdbc41",
     "slf4j"        -> "1.6.4",


### PR DESCRIPTION
A google search of my mysterious runtime exception finds a suggestion to
bump the version of akka to 2.3.12:

  https://groups.google.com/forum/#!topic/akka-user/T7GRNig631o

I used the sbt command

  show compile:dependencyClasspath

to list the versions used, and I confirm that in the configuration in
which things work (when I use scala-interop-0.0.9-SNAPSHOT and
scala-utils-0.0.12-SNAPSHOT), sbt somehow decides to use akka-2.3.12,
whereas in the configuration in which things don't work (when I use
scala-interop-0.0.8 and scala-utils-0.0.11), sbt sticks to the version I
have specified, akka-2.3.9, which is apparently the wrong version.

So I'm confident that the fix will work, and if the error occurs again,
I'll know where to look in order to figure out which version of which
library to bump.
