### PR TITLE
change string interpolation for TypedValues

### DIFF
--- a/src/main/scala/com/keatext/mintosci/scalautils/TypedValue.scala
+++ b/src/main/scala/com/keatext/mintosci/scalautils/TypedValue.scala
@@ -28,6 +28,10 @@ trait TypedValue[T] {
   // we override toString() to get that behavior.
   override def toString: String =
     value.toString
+
+  // For those cases when we do prefer "ItemId(1234)".
+  def show: String =
+    s"${this.getClass.getSimpleName}(${value.toString})"
 }
 
 object TypedValue {

--- a/src/main/scala/com/keatext/mintosci/scalautils/TypedValue.scala
+++ b/src/main/scala/com/keatext/mintosci/scalautils/TypedValue.scala
@@ -19,6 +19,15 @@ import scala.reflect.ClassTag
 //
 trait TypedValue[T] {
   val value: T
+
+  // There are two cases in which string interpolation syntax is likely to be used with TypedValues:
+  //   - s"${itemId} not found"
+  //   - s"/items/${itemId}/create"
+  // While for the first case we prefer "ItemId(1234) not found" to "1234 not found", so we can see at a glance
+  // what kind of thing was not found, the second case is more important, and we prefer "/items/1234/create", so
+  // we override toString() to get that behavior.
+  override def toString: String =
+    value.toString
 }
 
 object TypedValue {


### PR DESCRIPTION
I really hate to do this, because when debugging, I much prefer when
printed values tell me how they were constructed rather than what they
contain. But we will often replace plain value by typed values, and the
compiler will remind us to add ".value" almost everywhere, except in
string interpolations where the behaviour will be silently broken. Since
we can't force string interpolation to be a type error, we change
toString so that string interpolation behaves the same as before the
change.
